### PR TITLE
Add "refresh network list" button to captive portal

### DIFF
--- a/portal/templates/base.html
+++ b/portal/templates/base.html
@@ -54,18 +54,31 @@
         color: #999;
     }
 
-    .btn-submit {
-        width: 100%;
-        padding: 10px;
+    .btn {
         border: none;
-        background-color: #007bff;
-        color: white;
         border-radius: 4px;
+        color: white;
         cursor: pointer;
+        padding: 10px;
+    }
+
+    .btn-submit {
+        background-color: #007bff;
+        width: 100%;
     }
 
     .btn-submit:hover {
         background-color: #0056b3;
+    }
+
+    .btn-refresh {
+        background-color: slateblue;
+        margin-top: 36px;
+        width: 50%;
+    }
+
+    .btn-refresh:hover {
+        background-color: darkslateblue;
     }
 </style>
   {{ template "scripts" }}

--- a/portal/templates/index.html
+++ b/portal/templates/index.html
@@ -39,7 +39,9 @@
       <input type="text" name="password" id="password" placeholder="Password">
     </div>
     
-    <button id="submit" class="btn-submit" type="submit" onclick="submitForm()">Save</button>
+    <button id="submit" class="btn btn-submit" type="submit" onclick="submitForm()">Save</button>
   </form>
+
+  <button class="btn btn-refresh" onclick="location.reload()">Refresh Network List</button>
 </div>
 {{end}}


### PR DESCRIPTION
To make it easier for users to refresh the wifi network list. For example, if they turn on their hotspot after turn it on their smart machine. 

<details><summary>Browser Screenshot</summary>
<p>

<img width="1389" alt="Screenshot 2024-02-05 at 11 20 56 AM" src="https://github.com/viamrobotics/agent-provisioning/assets/1709578/a68828cb-6d54-498e-b729-beb7fdaec6e2">

</p>
</details> 

<details><summary>Mobile Screenshot</summary>
<p>

<img width="508" alt="Screenshot 2024-02-05 at 11 21 27 AM" src="https://github.com/viamrobotics/agent-provisioning/assets/1709578/2fe7b556-fa2d-499a-9500-847a4a7fd2ab">


</p>
</details> 
