### PR TITLE
[APP-5849] Static Network Configuration

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -35,6 +35,7 @@ linters:
     - maintidx
     - maligned
     - makezero
+    - mnd
     - musttag
     - nestif
     - nlreturn

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ clean:
 	rm -rf bin/
 
 bin/golangci-lint:
-	GOBIN=`pwd`/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
+	GOBIN=`pwd`/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@1.60.1
 
 .PHONY: lint
 lint: bin/golangci-lint

--- a/networkmanager/definitions.go
+++ b/networkmanager/definitions.go
@@ -28,6 +28,7 @@ const (
 
 	NetworkTypeWifi    = "wifi"
 	NetworkTypeHotspot = "hotspot"
+	NetworkTypeWired   = "wired"
 )
 
 var (
@@ -64,11 +65,21 @@ type NMWrapper struct {
 
 	// locking for data updates
 	dataMu      sync.Mutex
+
+	// key is interface@ssid for wifi, ex: wlan0@TestNetwork
+	// interface may be "any" for no interface set, ex: any@TestNetwork
+	// wired networks are just interface, ex: eth0
 	networks    map[string]*network
+
+	// the wifi device used by provisioning and actively managed for connectivity
+	hotspotInterface string
 	hotspotSSID string
-	activeSSID  string
 	lastSSID    string
-	primarySSID string
+
+	// key is interface name, ex: wlan0
+	primarySSID map[string]string
+	activeSSID  map[string]string
+
 	errors      []error
 
 	// portal
@@ -96,6 +107,7 @@ type network struct {
 	connected     bool
 	lastConnected time.Time
 	lastError     error
+	interfaceName string
 
 	conn       gnm.Connection
 	activeConn gnm.ActiveConnection

--- a/networkmanager/definitions.go
+++ b/networkmanager/definitions.go
@@ -3,7 +3,6 @@ package networkmanager
 import (
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -54,7 +53,6 @@ type NMWrapper struct {
 
 	// only set during NewNMWrapper, no lock
 	nm          gnm.NetworkManager
-	dev         gnm.DeviceWireless
 	settings    gnm.Settings
 	hostname    string
 	logger      *zap.SugaredLogger
@@ -81,6 +79,9 @@ type NMWrapper struct {
 	primarySSID map[string]string
 	activeSSID  map[string]string
 	lastSSID    map[string]string
+	activeConn  map[string]gnm.ActiveConnection
+	ethDevices  map[string]gnm.DeviceWired
+	wifiDevices map[string]gnm.DeviceWireless
 
 	errors []error
 
@@ -111,8 +112,7 @@ type network struct {
 	lastError     error
 	interfaceName string
 
-	conn       gnm.Connection
-	activeConn gnm.ActiveConnection
+	conn gnm.Connection
 }
 
 func (n *network) getInfo() provisioning.NetworkInfo {
@@ -129,15 +129,4 @@ func (n *network) getInfo() provisioning.NetworkInfo {
 		Connected: n.connected,
 		LastError: errStr,
 	}
-}
-
-func genNetKey(ifName, ssid string) string {
-	if ifName == "" {
-		ifName = "any"
-	}
-
-	if ssid == "" {
-		return ifName
-	}
-	return fmt.Sprintf("%s@%s", ssid, ifName)
 }

--- a/networkmanager/generators.go
+++ b/networkmanager/generators.go
@@ -1,55 +1,170 @@
 package networkmanager
 
 import (
+	"encoding/binary"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+
 	gnm "github.com/Otterverse/gonetworkmanager/v2"
 	"github.com/google/uuid"
+	errw "github.com/pkg/errors"
+	provisioning "github.com/viamrobotics/agent-provisioning"
 )
 
 // This file contains the wifi/hotspot setting generation functions.
 
-func generateWifiSettings(id, ssid, psk string, priority int32) gnm.ConnectionSettings {
-	settings := gnm.ConnectionSettings{
-		"connection": map[string]interface{}{
-			"id":                   id,
-			"uuid":                 uuid.New().String(),
-			"type":                 "802-11-wireless",
-			"autoconnect":          true,
-			"autoconnect-priority": priority,
-		},
-		"802-11-wireless": map[string]interface{}{
-			"mode": "infrastructure",
-			"ssid": []byte(ssid),
-		},
-	}
-	if psk != "" {
-		settings["802-11-wireless-security"] = map[string]interface{}{"key-mgmt": "wpa-psk", "psk": psk}
-	}
-	return settings
-}
-
 func generateHotspotSettings(id, ssid, psk string) gnm.ConnectionSettings {
 	settings := gnm.ConnectionSettings{
-		"connection": map[string]interface{}{
+		"connection": map[string]any{
 			"id":          id,
 			"uuid":        uuid.New().String(),
 			"type":        "802-11-wireless",
 			"autoconnect": false,
 		},
-		"802-11-wireless": map[string]interface{}{
+		"802-11-wireless": map[string]any{
 			"mode": "ap",
 			"ssid": []byte(ssid),
 		},
-		"802-11-wireless-security": map[string]interface{}{
+		"802-11-wireless-security": map[string]any{
 			"key-mgmt": "wpa-psk",
 			"psk":      psk,
 		},
-		"ipv4": map[string]interface{}{
+		"ipv4": map[string]any{
 			"method":    "shared",
 			"addresses": [][]uint32{{IPAsUint32, 24, IPAsUint32}},
 		},
-		"ipv6": map[string]interface{}{
+		"ipv6": map[string]any{
 			"method": "disabled",
 		},
 	}
 	return settings
+}
+
+
+func generateNetworkSettings(id string, cfg provisioning.NetworkConfig) (gnm.ConnectionSettings, error) {
+	settings := gnm.ConnectionSettings{}
+	if id == "" {
+		return nil, errw.New("id cannot be empty")
+	}
+
+	var netType string
+	switch cfg.Type {
+	case provisioning.NetworkWifi:
+		netType = "802-11-wireless"
+	case provisioning.NetworkWired:
+		netType = "802-3-ethernet"
+	default:
+		return nil, errw.Errorf("unknown network type: %s", cfg.Type)
+	}
+
+	settings["connection"]= map[string]any{
+			"id":                   id,
+			"uuid":                 uuid.New().String(),
+			"type":                 netType,
+			"autoconnect":          true,
+			"autoconnect-priority": cfg.Priority,
+	}
+
+	if cfg.Interface != "" {
+		settings["connection"]["interface-name"] = cfg.Interface
+	}
+
+	// Handle Wifi
+	if cfg.Type == provisioning.NetworkWifi {
+		settings["802-11-wireless"] = map[string]any{
+			"mode": "infrastructure",
+			"ssid": []byte(cfg.SSID),
+		}
+		if cfg.PSK != "" {
+			settings["802-11-wireless-security"] = map[string]any{"key-mgmt": "wpa-psk", "psk": cfg.PSK}
+		}
+	}
+
+	// Handle IP Config
+	ip4, err := generateIPv4Settings(cfg)
+	if err != nil {
+		return settings, err
+	}
+	settings["ipv4"] = ip4
+
+	return settings, nil
+}
+
+func generateIPv4Settings(cfg provisioning.NetworkConfig) (map[string]any, error) {
+	// -1 is special for "automatic"
+	if cfg.IPv4RouteMetric == 0 {
+		cfg.IPv4RouteMetric = -1
+	}
+
+	if cfg.IPv4Address == "" {
+		return map[string]any{"method": "auto", "route-metric": cfg.IPv4RouteMetric}, nil
+	}
+
+	// CIDR format, ex: 192.168.0.1/24
+	ip4Regex := regexp.MustCompile(`^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})/?([0-9]{1,2})?$`)
+	ret := ip4Regex.FindStringSubmatch(cfg.IPv4Address)
+	if len(ret) != 3 {
+		return nil, errw.Errorf("invalid ipv4 address: %s", cfg.IPv4Address)
+	}
+
+	ip, err := generateAddress(ret[1])
+	if err != nil {
+		return nil, err
+	}
+
+	gateway, err := generateAddress(cfg.IPv4Gateway)
+	if err != nil {
+		return nil, err
+	}
+
+	mask, err := strconv.ParseUint(ret[2], 10, 32)
+	if err != nil {
+		return nil, errw.Wrapf(err, "parsing ipv4 netmask: %s", cfg.IPv4Address)
+	}
+
+	ip4 := map[string]any{
+		"method": "manual",
+		"addresses": [][]uint32{{ip, uint32(mask), gateway}},
+		"route-metric": cfg.IPv4RouteMetric,
+	}
+
+	if len(cfg.IPv4DNS) > 0 {
+		var dnsData []uint32
+		for _, dns := range cfg.IPv4DNS {
+			dnsInt, err := generateAddress(dns)
+			if err != nil {
+				return nil, errw.Errorf("error parsing DNS ipv4 address: %s", dns)
+			}
+			dnsData = append(dnsData, dnsInt) 
+		}
+		ip4["dns"] = dnsData
+	}
+
+	return ip4, nil
+}
+
+// converts an ipv4 string (192.168.0.1) to a uint32 in network byte order
+func generateAddress(addr string) (uint32, error) {
+	// double-check with another library for correctness
+	if net.ParseIP(addr) == nil {
+		errw.Errorf("parsing ipv4: %s", addr)
+	}
+
+	ret := strings.Split(addr, ".")
+	if len(ret) != 4 {
+		return 0, errw.Errorf("parsing ipv4: %s", addr)
+	}
+
+	var outBytes []byte
+	for _, nibble := range ret {
+		b, err := strconv.ParseUint(nibble, 10, 8)
+		if err != nil {
+			return 0, errw.Errorf("parsing ipv4: %s", addr)
+		}
+		outBytes = append(outBytes, byte(b))
+	}
+
+	return binary.LittleEndian.Uint32(outBytes), nil
 }

--- a/networkmanager/generators.go
+++ b/networkmanager/generators.go
@@ -10,6 +10,7 @@ import (
 	gnm "github.com/Otterverse/gonetworkmanager/v2"
 	"github.com/google/uuid"
 	errw "github.com/pkg/errors"
+
 	provisioning "github.com/viamrobotics/agent-provisioning"
 )
 
@@ -42,7 +43,6 @@ func generateHotspotSettings(id, ssid, psk string) gnm.ConnectionSettings {
 	return settings
 }
 
-
 func generateNetworkSettings(id string, cfg provisioning.NetworkConfig) (gnm.ConnectionSettings, error) {
 	settings := gnm.ConnectionSettings{}
 	if id == "" {
@@ -59,12 +59,12 @@ func generateNetworkSettings(id string, cfg provisioning.NetworkConfig) (gnm.Con
 		return nil, errw.Errorf("unknown network type: %s", cfg.Type)
 	}
 
-	settings["connection"]= map[string]any{
-			"id":                   id,
-			"uuid":                 uuid.New().String(),
-			"type":                 netType,
-			"autoconnect":          true,
-			"autoconnect-priority": cfg.Priority,
+	settings["connection"] = map[string]any{
+		"id":                   id,
+		"uuid":                 uuid.New().String(),
+		"type":                 netType,
+		"autoconnect":          true,
+		"autoconnect-priority": cfg.Priority,
 	}
 
 	if cfg.Interface != "" {
@@ -125,8 +125,8 @@ func generateIPv4Settings(cfg provisioning.NetworkConfig) (map[string]any, error
 	}
 
 	ip4 := map[string]any{
-		"method": "manual",
-		"addresses": [][]uint32{{ip, uint32(mask), gateway}},
+		"method":       "manual",
+		"addresses":    [][]uint32{{ip, uint32(mask), gateway}},
 		"route-metric": cfg.IPv4RouteMetric,
 	}
 
@@ -137,7 +137,7 @@ func generateIPv4Settings(cfg provisioning.NetworkConfig) (map[string]any, error
 			if err != nil {
 				return nil, errw.Errorf("error parsing DNS ipv4 address: %s", dns)
 			}
-			dnsData = append(dnsData, dnsInt) 
+			dnsData = append(dnsData, dnsInt)
 		}
 		ip4["dns"] = dnsData
 	}
@@ -145,23 +145,24 @@ func generateIPv4Settings(cfg provisioning.NetworkConfig) (map[string]any, error
 	return ip4, nil
 }
 
-// converts an ipv4 string (192.168.0.1) to a uint32 in network byte order
+// converts an ipv4 string (192.168.0.1) to a uint32 in network byte order.
 func generateAddress(addr string) (uint32, error) {
+	parseErr := errw.Errorf("parsing ipv4: %s", addr)
 	// double-check with another library for correctness
 	if net.ParseIP(addr) == nil {
-		errw.Errorf("parsing ipv4: %s", addr)
+		return 0, parseErr
 	}
 
 	ret := strings.Split(addr, ".")
 	if len(ret) != 4 {
-		return 0, errw.Errorf("parsing ipv4: %s", addr)
+		return 0, parseErr
 	}
 
 	var outBytes []byte
 	for _, nibble := range ret {
 		b, err := strconv.ParseUint(nibble, 10, 8)
 		if err != nil {
-			return 0, errw.Errorf("parsing ipv4: %s", addr)
+			return 0, parseErr
 		}
 		outBytes = append(outBytes, byte(b))
 	}

--- a/networkmanager/generators.go
+++ b/networkmanager/generators.go
@@ -2,6 +2,7 @@ package networkmanager
 
 import (
 	"encoding/binary"
+	"fmt"
 	"net"
 	"regexp"
 	"strconv"
@@ -16,13 +17,14 @@ import (
 
 // This file contains the wifi/hotspot setting generation functions.
 
-func generateHotspotSettings(id, ssid, psk string) gnm.ConnectionSettings {
+func generateHotspotSettings(id, ssid, psk, ifName string) gnm.ConnectionSettings {
 	settings := gnm.ConnectionSettings{
 		"connection": map[string]any{
-			"id":          id,
-			"uuid":        uuid.New().String(),
-			"type":        "802-11-wireless",
-			"autoconnect": false,
+			"id":             id,
+			"uuid":           uuid.New().String(),
+			"type":           "802-11-wireless",
+			"autoconnect":    false,
+			"interface-name": ifName,
 		},
 		"802-11-wireless": map[string]any{
 			"mode": "ap",
@@ -168,4 +170,15 @@ func generateAddress(addr string) (uint32, error) {
 	}
 
 	return binary.LittleEndian.Uint32(outBytes), nil
+}
+
+func GenNetKey(ifName, ssid string) string {
+	if ifName == "" {
+		ifName = "any"
+	}
+
+	if ssid == "" {
+		return ifName
+	}
+	return fmt.Sprintf("%s@%s", ssid, ifName)
 }

--- a/networkmanager/grpc.go
+++ b/networkmanager/grpc.go
@@ -53,7 +53,7 @@ func (w *NMWrapper) GetSmartMachineStatus(ctx context.Context,
 		Errors:                     w.errListAsStrings(),
 	}
 
-	lastNetwork, ok := w.networks[w.lastSSID]
+	lastNetwork, ok := w.networks[w.lastSSID[w.hotspotInterface]]
 	if ok {
 		lastNetworkInfo := lastNetwork.getInfo()
 		ret.LatestConnectionAttempt = provisioning.NetworkInfoToProto(&lastNetworkInfo)
@@ -82,8 +82,8 @@ func (w *NMWrapper) SetNetworkCredentials(ctx context.Context,
 	w.input.PSK = req.GetPsk()
 	w.inputReceived.Store(true)
 
-	if req.GetSsid() == w.lastSSID && w.lastSSID != "" {
-		lastNetwork, ok := w.networks[w.lastSSID]
+	if req.GetSsid() == w.lastSSID[w.hotspotInterface] && w.lastSSID[w.hotspotInterface] != "" {
+		lastNetwork, ok := w.networks[w.lastSSID[w.hotspotInterface]]
 		if ok {
 			lastNetwork.lastError = nil
 		}
@@ -135,7 +135,7 @@ func (w *NMWrapper) GetNetworkList(ctx context.Context,
 func (w *NMWrapper) errListAsStrings() []string {
 	errList := []string{}
 
-	lastNetwork, ok := w.networks[w.lastSSID]
+	lastNetwork, ok := w.networks[w.lastSSID[w.hotspotInterface]]
 
 	if ok && lastNetwork.lastError != nil {
 		errList = append(errList, fmt.Sprintf("SSID: %s: %s", lastNetwork.ssid, lastNetwork.lastError))

--- a/networkmanager/portal.go
+++ b/networkmanager/portal.go
@@ -204,8 +204,8 @@ func (w *NMWrapper) portalSave(resp http.ResponseWriter, req *http.Request) {
 			w.banner += "Added credentials for SSID: " + w.input.SSID
 		}
 
-		if ssid == w.lastSSID && ssid != "" {
-			lastNetwork, ok := w.networks[w.lastSSID]
+		if ssid == w.lastSSID[w.hotspotInterface] && ssid != "" {
+			lastNetwork, ok := w.networks[w.lastSSID[w.hotspotInterface]]
 			if ok {
 				lastNetwork.lastError = nil
 			}

--- a/networkmanager/scanning.go
+++ b/networkmanager/scanning.go
@@ -4,7 +4,6 @@ package networkmanager
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -54,7 +53,6 @@ func (w *NMWrapper) NetworkScan(ctx context.Context) error {
 	now := time.Now()
 	for _, ap := range wifiList {
 		if ctx.Err() != nil {
-			//nolint:nilerr
 			return nil
 		}
 		ssid, err := ap.GetPropertySSID()
@@ -109,7 +107,6 @@ func (w *NMWrapper) NetworkScan(ctx context.Context) error {
 
 	for _, nw := range w.networks {
 		if ctx.Err() != nil {
-			//nolint:nilerr
 			return nil
 		}
 
@@ -186,7 +183,7 @@ func (w *NMWrapper) updateKnownConnections(ctx context.Context) error {
 		nw, ok := w.networks[netKey]
 		if !ok {
 			nw = &network{
-				netType: netType,
+				netType:       netType,
 				interfaceName: ifName,
 			}
 			if netType == NetworkTypeWifi {
@@ -267,7 +264,7 @@ func getKeyIfNameTypeFromSettings(settings gnm.ConnectionSettings) (string, stri
 	}
 
 	ifName := "any"
-	conn, ok  := settings["connection"]
+	conn, ok := settings["connection"]
 	if ok {
 		ifKey, ok := conn["interface-name"]
 		if ok {
@@ -279,7 +276,7 @@ func getKeyIfNameTypeFromSettings(settings gnm.ConnectionSettings) (string, stri
 	}
 
 	if wired {
-		return ifName, ifName, NetworkTypeWired
+		return genNetKey(ifName, ""), ifName, NetworkTypeWired
 	}
 
 	if wireless {
@@ -287,7 +284,7 @@ func getKeyIfNameTypeFromSettings(settings gnm.ConnectionSettings) (string, stri
 		if ssid == "" {
 			return "", "", ""
 		}
-		return fmt.Sprintf("%s@%s", ifName, ssid), ifName, NetworkTypeWifi
+		return genNetKey(ifName, ssid), ifName, NetworkTypeWifi
 	}
 
 	return "", "", ""

--- a/networkmanager/setup.go
+++ b/networkmanager/setup.go
@@ -104,13 +104,14 @@ func (w *NMWrapper) initWifiDev() error {
 		if devType == gnm.NmDeviceTypeWifi && w.dev == nil {
 			wifiDev, ok := device.(gnm.DeviceWireless)
 			if ok {
-				ifName, err := w.dev.GetPropertyInterface()
+				ifName, err := wifiDev.GetPropertyInterface()
 				if err != nil {
 					return err
 				}
 				if w.hotspotInterface == "" || ifName == w.cfg.HotspotInterface {
 					w.hotspotInterface = ifName
 					w.dev = wifiDev
+					w.logger.Info("Using %s for hotspot/provisioning, will actively manage wifi only on this device.", ifName)
 				}
 			}
 		}

--- a/provisioning.go
+++ b/provisioning.go
@@ -84,27 +84,27 @@ func NetworkInfoFromProto(buf *pb.NetworkInfo) *NetworkInfo {
 
 type NetworkConfig struct {
 	// "wifi", "wired", "wifi-static", "wired-static"
-	Type     string `json:"type"`
+	Type string `json:"type"`
 
 	// name of interface, ex: "wlan0", "eth0", "enp14s0", etc.
 	Interface string `json:"interface"`
 
 	// Wifi Settings
-	SSID     string `json:"ssid"`
-	PSK      string `json:"psk"`
+	SSID string `json:"ssid"`
+	PSK  string `json:"psk"`
 
-	// Autoconnect Priority (primarly for wifi)
+	// Autoconnect Priority (primarily for wifi)
 	// higher values are preferred/tried first
 	// defaults to 0, but wifi networks added via hotspot are set to 999 when not in roaming mode
-	Priority int32  `json:"priority"`
+	Priority int32 `json:"priority"`
 
 	// CIDR format address, ex: 192.168.0.1/24
 	// If unset, will default to "auto" (dhcp)
-	IPv4Address     string `json:"ipv4_address"`
-	IPv4Gateway     string `json:"ipv4_gateway"`
+	IPv4Address string `json:"ipv4_address"`
+	IPv4Gateway string `json:"ipv4_gateway"`
 
 	// optional
-	IPv4DNS         []string `json:"ipv4_dns"`
+	IPv4DNS []string `json:"ipv4_dns"`
 
 	// optional, 0 or -1 is default
 	// lower values are preferred (lower "cost")
@@ -114,10 +114,9 @@ type NetworkConfig struct {
 }
 
 const (
-	NetworkWifi = "wifi"
+	NetworkWifi  = "wifi"
 	NetworkWired = "wired"
 )
-
 
 // DeviceConfig represents the minimal needed for /etc/viam.json.
 type DeviceConfig struct {
@@ -251,7 +250,7 @@ func (t Timeout) MarshalJSON() ([]byte, error) {
 }
 
 func (t *Timeout) UnmarshalJSON(b []byte) error {
-	var v interface{}
+	var v any
 	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}

--- a/provisioning.go
+++ b/provisioning.go
@@ -83,11 +83,41 @@ func NetworkInfoFromProto(buf *pb.NetworkInfo) *NetworkInfo {
 }
 
 type NetworkConfig struct {
+	// "wifi", "wired", "wifi-static", "wired-static"
 	Type     string `json:"type"`
+
+	// name of interface, ex: "wlan0", "eth0", "enp14s0", etc.
+	Interface string `json:"interface"`
+
+	// Wifi Settings
 	SSID     string `json:"ssid"`
 	PSK      string `json:"psk"`
+
+	// Autoconnect Priority (primarly for wifi)
+	// higher values are preferred/tried first
+	// defaults to 0, but wifi networks added via hotspot are set to 999 when not in roaming mode
 	Priority int32  `json:"priority"`
+
+	// CIDR format address, ex: 192.168.0.1/24
+	// If unset, will default to "auto" (dhcp)
+	IPv4Address     string `json:"ipv4_address"`
+	IPv4Gateway     string `json:"ipv4_gateway"`
+
+	// optional
+	IPv4DNS         []string `json:"ipv4_dns"`
+
+	// optional, 0 or -1 is default
+	// lower values are preferred (lower "cost")
+	// wired networks default to 100
+	// wireless networks default to 600
+	IPv4RouteMetric int64 `json:"ipv4_route_metric"`
 }
+
+const (
+	NetworkWifi = "wifi"
+	NetworkWired = "wired"
+)
+
 
 // DeviceConfig represents the minimal needed for /etc/viam.json.
 type DeviceConfig struct {
@@ -186,6 +216,9 @@ type Config struct {
 	Model        string `json:"model"`
 	FragmentID   string `json:"fragment_id"`
 
+	// The interface to use for hotspot/provisioning/wifi management. Ex: "wlan0"
+	// Defaults to the first discovered 802.11 device
+	HotspotInterface string `json:"hotspot_interface"`
 	// The prefix to prepend to the hotspot name.
 	HotspotPrefix string `json:"hotspot_prefix"`
 	// Password required to connect to the hotspot.


### PR DESCRIPTION
The code still needs cleanup, and I expect there are definitely undiscovered bugs still. Unfortunately had to change a lot more of the core functionality than I had hoped, so we will definitely need to test thoroughly to make sure previously implemented behavior is still fully functional.

That said, it's functional at this point, and ready to be tried out. Example config is below.

```json
  "agent-provisioning": {
    "pin_url": "https://storage.googleapis.com/packages.viam.com/temp/viam-agent-provisioning-netconfbeta-aarch64",
    "attributes": {
      "roaming_mode": true,
      "hotspot_interface": "wlan1",
      "networks": [
        {
          "type": "wifi",
          "ssid": "TestNetwork",
          "psk": "foobar99",
          "priority": 600,
          "ipv4_address": "192.168.1.155/24",
          "ipv4_gateway": "192.168.1.254",
          "ipv4_route_metric": 200,
          "ipv4_dns": [
            "8.8.8.8",
            "8.8.4.4"
          ]
        },
        {
          "type": "wired",
          "interface": "eth0",
          "priority": 300,
          "ipv4_address": "192.168.1.156/24",
          "ipv4_gateway": "192.168.1.254",
          "ipv4_route_metric": 150,
          "ipv4_dns": [
            "8.8.8.8",
            "8.8.4.4"
          ]
        }
      ]
    }
  }
```

`hotspot_interface` is optional, (default to the first wifi device discovered, as it always has) but can be used to force a specific device

`type` can be `wired` or `wifi` as shown

`interface` is optional for wifi (networks with it unset will use the hotspot_interface, same as prior behavior), but functionally required for wired devices.`

`priority` is the "autoconnect-priority" setting in NetworkManager. -999 to 999, defaults to zero. Mostly unused for wired connections, but matters for wifi. Higher numbers are preferred.

`ipv4_address` is mostly self explanatory. If NOT set, will configure a network to "auto" mode (dhcp.) It's in CIDR format, the part after the slash is the prefix length used to generate the netmask.

`ipv4_gateway` is the default gateway to use for that network.

`ipv4_route_metric` is the literal linux routing metric for the gateway and subnet routes. Viewable in linux with `route` or `ip route` Is a positive integer greater than zero, defaults to 100 for wired networks, and 600 for wifi networks. Represents a "cost" for the route, so LOWER numbers are preferred. Can still be used for automatic networks as well (e.g. ones with no address/gateway/dns set)

`ipv4_dns` is an (optional) list of DNS servers to add to this network. DNS is not priortized, and ALL dns servers (along with any others from the OS) will end up in /etc/resolv.conf (typically.)


All networks are added (and attempted to be activated) at startup, or when the provisioning config is changed. Otherwise, only the main wifi adapter (`hotspot_interface`) is actively managed (same as prior behavior.)